### PR TITLE
Change Test all backups readable to exclude

### DIFF
--- a/functions/Test-DbaBackupInformation.ps1
+++ b/functions/Test-DbaBackupInformation.ps1
@@ -154,7 +154,16 @@ Function Test-DbaBackupInformation {
 			$allpaths = $DbHistory | Select-Object -ExpandProperty FullName
 			$allpaths_validity = Test-DbaSqlPath -SqlInstance $RestoreInstance -Path $allpaths
 			foreach ($path in $allpaths_validity) {
-				if ($path.FileExists -eq $false) {
+				
+				 if ($path -like 'http*') {
+					$deviceType = 'URL'
+					}
+					else {
+					    $deviceType = 'FILE'
+				}
+                
+				
+				if ($path.FileExists -eq $false -eq 'FILE') {
 					Write-Message -Message "Backup File $($path.FilePath) cannot be read" -Level Warning
 					$VerificationErrors++
 				}


### PR DESCRIPTION
The function cannot test files that are backed up on Azure blob storage as the Test-DbaSqlPath uses the sql command 'EXEC master.dbo.xp_fileexist'

<!-- Below information IS REQUIRED with every PR -->
## Type of Change
<!-- What type of change does your code introduce -->
 - [1 ] Bug fix (non-breaking change, fixes #<#3734>)
 - [ ] New feature (non-breaking change, adds functionality)
 - [ ] Breaking change (effects multiple commands or functionality)
 - [ ] Ran manual Pester test and has passed (`.\tests\manual.pester.ps1)
 - [ ] Adding code coverage to existing functionality
 - [ ] Pester test is included
 - [ ] Nunit test is included
 - [ ] Documentation
 - [ ] Build system
 
<!-- Below this line you can erase anything that is not applicable -->
### Purpose
<!-- What is the purpose or goal of this PR? (doesn't have to be an essay) --> 
When I provide a list of URL's for to Restore-Dbadatabase, the restore process fails on Test-DBABackupInformation stating that the backup file cannot be read.

Looking at Test-DBABackupInformation, I can see that the test validates the backup file paths by using the function Test-DbaSqlPath and this function will fail every time someone passes through a URL.

